### PR TITLE
continue if binding to the discovery port fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -232,7 +232,9 @@ func discoveryListen() {
 			log.Printf("UDP discovery port %d already in use. Inbound discovery disabled.", discPort)
 			return
 		} else {
-			log.Fatalf("Couldn't open UDP?!? %v", err)
+			log.Printf("Couldn't open UDP?!? %v", err)
+			log.Println("Discovery will not be possible")
+			return
 		}
 	}
 	for {


### PR DESCRIPTION
allows multiple clients to run on the same machine.
