### PR TITLE
So dropping messages means you can't copy and paste large blocks of text

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,12 +114,9 @@ func (p *Peers) List() []chan<- Message {
 
 func broadcast(m Message) {
 	for _, ch := range peers.List() {
-		select {
-		case ch <- m:
-		default:
-			// Okay to drop messages sometimes.
-		}
-	}
+		ch <- m
+    // Never drop the message!!!!!!
+  }
 }
 
 func serve(c net.Conn) {


### PR DESCRIPTION
Which apparently we all want to do.
